### PR TITLE
Authenticate with GitHub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# config
+config.json

--- a/src/App.js
+++ b/src/App.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import request from 'request-promise';
 import logo from './logo.svg';
 import './App.css';
+import config from './config';
 import UpdateUserForm from './UpdateUser';
 
 class App extends Component {
@@ -14,7 +15,7 @@ class App extends Component {
   }
 
   getGitHubData(user) {
-    request.get(`https://api.github.com/users/${user}`)
+    request.get(`https://api.github.com/users/${user}?access_token=${config.github_token}`)
       .then(data =>
         this.setState(() => {
           return { user: JSON.parse(data) }

--- a/src/config.example.json
+++ b/src/config.example.json
@@ -1,0 +1,3 @@
+{
+  "github_token": "Generate a new token at https://github.com/settings/tokens - it shouldn't need any special access"
+}


### PR DESCRIPTION
The GitHub API was rate limiting us as we weren't authenticating with them. This allows us to authenticate using our own GitHub account.

You will need to copy `config.example.json` to `config.json` and replace the value of `github_token` with a token generated from GitHub. Instructions on where to go to generate one of those tokens are in the example file.